### PR TITLE
day info modal

### DIFF
--- a/src/Calendar/Calendar.tsx
+++ b/src/Calendar/Calendar.tsx
@@ -30,10 +30,10 @@ const CalendarPage: React.SFC<CalendarProps> = ({ userDays }) => {
           value={givenDate}
           className='react-calendar'
         />
+     </section>
 			<DayInfo 
 				foundDay={dayForDetails}
 			/>
-     </section>
    </main>
   );
 }

--- a/src/Calendar/DayInfo.scss
+++ b/src/Calendar/DayInfo.scss
@@ -1,0 +1,27 @@
+.day-info-container {
+	border-radius: 10px;
+	background-color: #172A35;
+	margin-top: 15px;
+	height: 10vh;
+	width: 85vw;
+	align-items: center;
+	font-family: Arial, Helvetica, sans-serif;
+	display: flex;
+	justify-content: center;
+}
+
+.day-info {
+	display: flex;
+	padding: 10px;
+	background-color: white;
+	color: #233C4C;
+	border-radius: 10px;
+	height: 40%;
+	width: 90%;
+	font-size: .7em;
+	font-family: 'Capriola', sans-serif;
+}
+
+.date-head {
+	font-size: 1.5em;
+}

--- a/src/Calendar/DayInfo.tsx
+++ b/src/Calendar/DayInfo.tsx
@@ -1,25 +1,34 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import { Days } from '../App/App';
+import './DayInfo.scss'
 
 export interface DayInfoProps {
 	foundDay: Days | undefined;
 }
 
-const DayInfo: React.SFC<DayInfoProps> = ({ foundDay }) => {
-	const [ foundDate, setDate ] = useState(foundDay);
+const DayInfo: React.SFC<DayInfoProps> = (props) => {
+	const [ foundDate, setDate ] = useState(props.foundDay);
 	
+	useEffect(() => { setDate(props.foundDay) }, [ props ])
+
   return(
-     <section className='day-info-container'>
+		<section className='day-info-container'>
+			{console.log(foundDate)}
 			 {foundDate && foundDate.highRisk &&
-					<div>
-						{foundDate.Date}:
-						Today is a high risk fertility day, consider using other forms of birth control.
+					<div className='day-info'>
+						<div className='date-head'>{foundDate.Date}</div>
+						<div style={{ textAlign: 'left', marginLeft: '10px' }}><span style={{ color: 'red' }}>High risk</span> fertility day, consider using other forms of birth control.</div>
 					</div>
 			 }
 			 {foundDate && !foundDate.highRisk &&
-					<div>
-					{foundDate.Date}:
-					Today is a low risk fertility day, your chances of pregnancy are very low.
+					<div className='day-info'>
+						<div className='date-head'>{foundDate.Date}</div>
+						<div style={{ textAlign: 'left', marginLeft: '10px' }}><span style={{ color: 'green' }}>Low risk</span> fertility day, your chances of pregnancy are very low.</div>
+					</div>
+			 }
+			 {!foundDate &&
+					<div className='day-info'>
+					No logged information for this day.
 				</div>
 			 }
      </section>

--- a/src/index.css
+++ b/src/index.css
@@ -73,6 +73,7 @@ nav {
   font-family: 'Damion';
   color: #83C7DF;
 	font-size: 8vh;
+	margin: 5%;
 }
 
 .info-paragraph {


### PR DESCRIPTION
**Type of change made**:
- [ ] Configuration / setup
- [ ] Bugfix
- [x] New feature
- [ ] Styling
- [ ] Testing

**Detailed Description**:
Days clicked on in the calendar with logged information get populated onto a modal below the calendar.

**Screenshots (if applicable)**:
![Screen Shot 2020-09-14 at 2 52 13 PM](https://user-images.githubusercontent.com/59381432/93136976-03f4e900-f69a-11ea-95ed-c646f2983f1a.png)
![Screen Shot 2020-09-14 at 2 52 22 PM](https://user-images.githubusercontent.com/59381432/93136979-048d7f80-f69a-11ea-80cc-26177e22ceb6.png)
![Screen Shot 2020-09-14 at 2 52 33 PM](https://user-images.githubusercontent.com/59381432/93136983-048d7f80-f69a-11ea-8c5e-4fbd44869a4b.png)

**Questions leftover**:
As extension/enhancement I'd like to make this modal expandable & collapsable. Since this part wasn't so bad, maybe overlaying the calendar with a color code can be looked into tomorrow.