### PR TITLE
Feature/user prompts & few other things

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -21,30 +21,29 @@ export interface userDetails {
 	start_date: string,
 	avg_length: number,
 	avg_cycle: number,
+	name: string
 }
 
 const App = () => {
 	const [ username, setUsername ] = useState('');
 	const [ loggedIn, setLoggedIn ] = useState(false);
-
 	const [ days, setDays ] = useState<Days[]>([]);
-
 	const logoutUser= () => {
 		setUsername('')
 		setLoggedIn(false)
 	}
-
-	useEffect(() => {getUserDays()}, []);
 	const [ userData, setUserData ] = useState<userDetails[]>([
 		{
 			start_date: '',
 			avg_length: 0,
 			avg_cycle: 0,
+			name: ''
 		}
 	])
 	const [ error, setError ] = useState("");
-
+	
 	useEffect(() => {getUserDetails()}, [userData]);
+	useEffect(() => {getUserDays()}, []);
 	
 	const getUserDetails = async (): Promise<any> => {
 		try {
@@ -217,12 +216,12 @@ const App = () => {
 				highRisk: true
 			}
 		])
-		// try {
-		// 	const data = await getDays();
-		// 	return setDays(data);
-		// } catch (error) {
-		// 	setError(error.toString());
-		// }
+		try {
+			const data = await getDays();
+			return setDays(data);
+		} catch (error) {
+			setError(error.toString());
+		}
 	}
 
   return (
@@ -238,7 +237,7 @@ const App = () => {
 				/>
 				<Route 
 					path='/profile'
-					render={() => <Profile userData={userData} logoutUser={logoutUser} postUserData={postUserData} error={error}/>}
+					render={() => <Profile userData={userData} logoutUser={logoutUser} postUserData={postUserData} error={error} username={username} />}
 				/>
 				{loggedIn && 
 					<Route exact path='/' component={Home} />

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -13,9 +13,9 @@ import { getUserData, submitUserData, getDays } from "../apiCalls";
 import './App.css';
 
 export interface Days {
-	Temperature: number,
-	Date: string,
-	highRisk: boolean
+	temperature: number,
+	date: string,
+	high_risk: boolean
 }
 export interface userDetails {
 	start_date: string,
@@ -28,10 +28,6 @@ const App = () => {
 	const [ username, setUsername ] = useState('');
 	const [ loggedIn, setLoggedIn ] = useState(false);
 	const [ days, setDays ] = useState<Days[]>([]);
-	const logoutUser= () => {
-		setUsername('')
-		setLoggedIn(false)
-	}
 	const [ userData, setUserData ] = useState<userDetails[]>([
 		{
 			start_date: '',
@@ -45,6 +41,11 @@ const App = () => {
 	useEffect(() => {getUserDetails()}, [userData]);
 	useEffect(() => {getUserDays()}, []);
 	
+	const logoutUser= () => {
+		setUsername('')
+		setLoggedIn(false)
+	}
+
 	const getUserDetails = async (): Promise<any> => {
 		try {
 			const data = await getUserData();
@@ -64,158 +65,6 @@ const App = () => {
 	}
 
 	const getUserDays = async () => {
-		setDays([
-			{
-				Temperature: 97.3921407225235,
-				Date: '09/01/2020',
-				highRisk: false
-			},
-			{
-				Temperature: 97.45472336125859,
-				Date: '09/02/2020',
-				highRisk: false
-			},
-			{
-				Temperature: 97.37539305082102,
-				Date: '09/03/2020',
-				highRisk: false
-			},
-			{
-				Temperature: 97.39594321187163,
-				Date: '09/04/2020',
-				highRisk: false
-			},
-			{ 
-				Temperature: 97.22967507338001,
-				Date: '09/05/2020',
-				highRisk: false
-			},
-			{ 
-				Temperature: 97.15550167462081,
-				Date: '09/06/2020',
-				highRisk: false
-			},
-			{ 
-				Temperature: 97.37489920782173,
-				Date: '09/07/2020',
-				highRisk: false
-			},
-			{ 
-				Temperature: 97.32587582389289,
-				Date: '09/08/2020',
-				highRisk: false
-			},
-			{ 
-				Temperature: 97.2532495702544,
-				Date: '09/09/2020',
-				highRisk: false
-			},
-			{ 
-				Temperature: 97.47893633165044,
-				Date: '09/10/2020',
-				highRisk: false
-			},
-			{ 
-				Temperature: 97.12109556511471,
-				Date: '09/11/2020',
-				highRisk: false
-			},
-			{ 
-				Temperature: 97.39352202710452,
-				Date: '09/12/2020',
-				highRisk: false
-			},
-			{
-				Temperature: 97.39706814872008,
-				Date: '09/13/2020',
-				highRisk: false
-			},
-			{ 
-				Temperature: 97.20555830876744,
-				Date: '09/14/2020',
-				highRisk: false
-			},
-			{
-				Temperature: 97.49626383244673,
-				Date: '09/15/2020',
-				highRisk: false
-			},
-			{
-				Temperature: 97.24120211190903,
-				Date: '09/16/2020',
-				highRisk: false
-			},
-			{
-				Temperature: 98.34677713289109,
-				Date: '09/28/2020',
-				highRisk: false
-			},
-			{
-				Temperature: 97.70349779060184,
-				Date: '09/29/2020',
-				highRisk: false
-			},
-			{
-				Temperature: 98.5701435459597,
-				Date: '09/30/2020',
-				highRisk: false
-			},
-			{
-				Temperature: 97.32789902753188,
-				Date: '09/17/2020',
-				highRisk: true
-			},
-			{
-				Temperature: 97.33750832723287,
-				Date: '09/18/2020',
-				highRisk: true
-			},
-			{
-				Temperature: 97.49237121174019,
-				Date: '09/19/2020',
-				highRisk: true
-			},
-			{
-				Temperature: 97.10673653294982,
-				Date: '09/20/2020',
-				highRisk: true
-			},
-			{
-				Temperature: 97.45035457538701,
-				Date: '09/21/2020',
-				highRisk: true
-			},
-			{
-				Temperature: 97.39618222527686,
-				Date: '09/22/2020',
-				highRisk: true
-			},
-			{
-				Temperature: 97.18218490258948,
-				Date: '09/23/2020',
-				highRisk: true
-			},
-			{
-				Temperature: 98.31225964314442,
-				Date: '09/24/2020',
-				highRisk: true
-			},
-			{
-				Temperature: 97.70977277629115,
-				Date: '09/25/2020',
-				highRisk: true
-			},
-			{
-				Temperature: 98.5559779071062,
-				Date: '09/26/2020',
-				highRisk: true
-			},
-			{
-				Temperature: 98.29823570276363,
-				Date: '09/27/2020',
-				highRisk: true
-			}
-		])
 		try {
 			const data = await getDays();
 			return setDays(data);
@@ -229,7 +78,9 @@ const App = () => {
 			{loggedIn && <InfoTag username={username}/>}
 			<Switch>
 				<Route path='/info' component={Info} />
-				<Route path='/new-entry' component={Form} />
+				<Route path='/new-entry' 
+					render={() => <Form days={days}/>}
+				/>
 				<Route path='/stats' component={Reports} />
 				<Route 
 					path='/calendar' 

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -55,9 +55,9 @@ const App = () => {
 		}
 	}
 
-	const postUserData = async (startDate: string, avgLength: number, avgCycle: number): Promise<any> => {
+	const postUserData = async (startDate: string, avgLength: number, avgCycle: number, username: string): Promise<any> => {
 		try {
-			const data = await submitUserData(startDate, avgLength, avgCycle)
+			const data = await submitUserData(startDate, avgLength, avgCycle, username)
 			return data
 		} catch (error) {
 			setError(error.toString());
@@ -79,7 +79,7 @@ const App = () => {
 			<Switch>
 				<Route path='/info' component={Info} />
 				<Route path='/new-entry' 
-					render={() => <Form days={days}/>}
+					render={() => <Form days={days} getUserDays={getUserDays} />}
 				/>
 				<Route path='/stats' component={Reports} />
 				<Route 
@@ -91,7 +91,11 @@ const App = () => {
 					render={() => <Profile userData={userData} logoutUser={logoutUser} postUserData={postUserData} error={error} username={username} />}
 				/>
 				{loggedIn && 
-					<Route exact path='/' component={Home} />
+					<Route 
+						exact
+						path='/'
+						render={() => <Home days={days} />} 
+					/>
 				}
 				{!loggedIn && 
 					<Route 

--- a/src/Calendar/Calendar.tsx
+++ b/src/Calendar/Calendar.tsx
@@ -19,8 +19,8 @@ const CalendarPage: React.SFC<CalendarProps> = ({ userDays }) => {
 	useEffect(() => { parseRiskDays() }, [ userDays ])
 
 	const parseRiskDays = () => {
-		setHighRisk(userDays.filter(day => day.highRisk));
-		setLowRisk(userDays.filter(day => !day.highRisk));
+		setHighRisk(userDays.filter(day => day.high_risk));
+		setLowRisk(userDays.filter(day => !day.high_risk));
 	}
 
 	const clickedDayInfo = (e: any) => {
@@ -28,7 +28,7 @@ const CalendarPage: React.SFC<CalendarProps> = ({ userDays }) => {
 		const mm = String(e.getMonth() + 1).padStart(2, '0');
 		const yyyy = e.getFullYear();
 		const chosenDay = `${mm}/${dd}/${yyyy}`;
-		setDayForDetails(userDays.find(day => day.Date === chosenDay.toString()));
+		setDayForDetails(userDays.find(day => day.date === chosenDay.toString()));
 	}
 
   return(
@@ -40,9 +40,9 @@ const CalendarPage: React.SFC<CalendarProps> = ({ userDays }) => {
           value={givenDate}
 					className='react-calendeda798ar'
 					tileClassName={({ date, view }) => {
-						if (highRisk && highRisk.find(x => x.Date === moment(date).format("MM/DD/YYYY"))) {
+						if (highRisk && highRisk.find(x => x.date === moment(date).format("MM/DD/YYYY"))) {
 							return 'red-risk';	
-						} else if (lowRisk && lowRisk.find(x => x.Date === moment(date).format("MM/DD/YYYY"))) {
+						} else if (lowRisk && lowRisk.find(x => x.date === moment(date).format("MM/DD/YYYY"))) {
 							return 'green-risk';	
 						} else {
 							return 'react-calendar'

--- a/src/Calendar/DayInfo.tsx
+++ b/src/Calendar/DayInfo.tsx
@@ -13,15 +13,15 @@ const DayInfo: React.SFC<DayInfoProps> = (props) => {
 
   return(
 		<section className='day-info-container'>
-			 {foundDate && foundDate.highRisk &&
+			 {foundDate && foundDate.high_risk &&
 					<div className='day-info'>
-						<div className='date-head'>{foundDate.Date}</div>
+						<div className='date-head'>{foundDate.date}</div>
 						<div style={{ textAlign: 'left', marginLeft: '10px' }}><span style={{ color: 'red' }}>High risk</span> fertility day, consider using other forms of birth control.</div>
 					</div>
 			 }
-			 {foundDate && !foundDate.highRisk &&
+			 {foundDate && !foundDate.high_risk &&
 					<div className='day-info'>
-						<div className='date-head'>{foundDate.Date}</div>
+						<div className='date-head'>{foundDate.date}</div>
 						<div style={{ textAlign: 'left', marginLeft: '10px' }}><span style={{ color: 'green' }}>Low risk</span> fertility day, your chances of pregnancy are very low.</div>
 					</div>
 			 }

--- a/src/Form/Form.scss
+++ b/src/Form/Form.scss
@@ -11,7 +11,7 @@
 }
 
 form {
-	height: 70vh;
+	height: 75vh;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-evenly;

--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -3,17 +3,20 @@ import MultiSelect from "react-multi-select-component";
 import './Form.scss';
 import { Days } from '../App/App';
 import { submitDay } from '../apiCalls';
+import moment from 'moment';
 
 export interface FormProps {
 	days: Days[];
+	getUserDays: Function
 }
 
-const Form: React.FC<FormProps> = ({ days }) => {
+const Form: React.FC<FormProps> = ({ days, getUserDays }) => {
 	const [ today, setToday ] = useState('');
 	const [ temp, setTemp ] = useState('');
 	const [ time, setTime ] = useState('')
 	const [ selected, setSelected ] = useState([]);
 	const [ userDays, setUserDays ] = useState<Days[]>([]);
+	const [ confirmation, setConfirmation ] = useState(false);
 	const [ symptoms, setSymptoms ] = useState([
 		{label: 'Cramping', value: 'cramping'},
 		{label: 'Mood change', value: 'mood change'},
@@ -34,12 +37,7 @@ const Form: React.FC<FormProps> = ({ days }) => {
 	useEffect(() => { setUserDays(days) }, [ days ])
 
 	const getDate = () => {
-		var today = new Date();
-		var dd = String(today.getDate()).padStart(2, '0');
-		var mm = String(today.getMonth() + 1).padStart(2, '0');
-		var yyyy = today.getFullYear();
-
-		setToday(mm + '/' + dd + '/' + yyyy);
+		setToday(moment(new Date()).format("MM/DD/YYYY"));
 	}
 
 	const handleSubmit = async (event: any) => {
@@ -47,7 +45,8 @@ const Form: React.FC<FormProps> = ({ days }) => {
 		try {
 			const data = await submitDay(temp, today)
 			console.log(data);
-			//TODO: thanks for submission msg
+			setConfirmation(true);
+			getUserDays();
 		} catch (error) {
 			console.log(error)
 		}
@@ -143,9 +142,10 @@ const Form: React.FC<FormProps> = ({ days }) => {
 						className='submit'
 						type='button'
 						onClick={handleSubmit}
-					>
+						>
 						SUBMIT
 					</button>
+					{confirmation && <div style={{ fontStyle: 'italic', color: '#FBCE90', fontSize: '.8em', marginLeft: '17%' }}>Entry submitted</div>}
 				</form>
 			}
 		</main>

--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -1,14 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import MultiSelect from "react-multi-select-component";
 import './Form.scss';
+import { Days } from '../App/App';
 import { submitDay } from '../apiCalls';
 
+export interface FormProps {
+	days: Days[];
+}
 
-const Form: React.FC = () => {
+const Form: React.FC<FormProps> = ({ days }) => {
 	const [ today, setToday ] = useState('');
 	const [ temp, setTemp ] = useState('');
 	const [ time, setTime ] = useState('')
 	const [ selected, setSelected ] = useState([]);
+	const [ userDays, setUserDays ] = useState<Days[]>([]);
 	const [ symptoms, setSymptoms ] = useState([
 		{label: 'Cramping', value: 'cramping'},
 		{label: 'Mood change', value: 'mood change'},
@@ -26,6 +31,7 @@ const Form: React.FC = () => {
 ])
 
 	useEffect(() => {getDate()}, []);
+	useEffect(() => { setUserDays(days) }, [ days ])
 
 	const getDate = () => {
 		var today = new Date();
@@ -41,6 +47,7 @@ const Form: React.FC = () => {
 		try {
 			const data = await submitDay(temp, today)
 			console.log(data);
+			//TODO: thanks for submission msg
 		} catch (error) {
 			console.log(error)
 		}
@@ -48,51 +55,99 @@ const Form: React.FC = () => {
 
   return (
 		<main className='Main-User-View'>
-			<form>
-				<label>Today: {today}</label>
-				<label>Time:
-					<input 
-						type="time"
-						name="time"
-						style={{ width: '45%' }}
-						className='input'
-						onChange={e => setTime(e.target.value)}
-						required 
+			
+			{days.find(x => x.date === today) && 
+				<form>
+					<div style={{color: 'grey', fontStyle: 'italic', textAlign: 'center', fontSize: '2.5vh'}}>You already filled out today's log!</div>
+					<label>Today: {today}</label>
+					<label>Time:
+						<input 
+							type="time"
+							name="time"
+							style={{ width: '45%' }}
+							className='input'
+							disabled
+						/>
+					</label>
+					<label className='temp-label'>Temp:
+						<input
+							name="temp"
+							type="number"
+							min="90"
+							max="110"
+							placeholder='--'
+							value={temp}
+							className='input'
+							aria-label='temperature-input'
+							disabled
 					/>
-				</label>
-				<label className='temp-label'>Temp:
-					<input
-						name="temp"
-						type="number"
-						min="90"
-						max="110"
-						placeholder='--'
-						value={temp}
-						className='input'
-						aria-label='temperature-input'
-						onChange={e => setTemp(e.target.value)} 
-					/>
-					<div className='BBT-deg'>°F</div>
-				</label>
-				<label>Symptoms:
-					<MultiSelect
-						options={symptoms}
-						value={selected}
-						onChange={setSelected}
-						labelledBy={"Select"}
-						className='multi-select'
-					/>
-				</label>
-				<button
-					className='submit'
-					type='button'
-					onClick={handleSubmit}
-				>
-					SUBMIT
-				</button>
-				{/* <input type='submit' value='SUBMIT' className='submit' /> */}
-			</form>
+						<div className='BBT-deg'>°F</div>
+					</label>
+					<label>Symptoms:
+						<MultiSelect
+							options={symptoms}
+							value={selected}
+							labelledBy={"Select"}
+							className='multi-select'
+							disabled
+						/>
+					</label>
+					<button
+						className='submit'
+						type='button'						
+						style={{backgroundColor: 'grey'}}
+						disabled
+					>
+						SUBMIT
+					</button>
+				</form>
+			}
 
+			{!days.find(x => x.date === today) &&
+				<form>
+					<label>Today: {today}</label>
+					<label>Time:
+						<input 
+							type="time"
+							name="time"
+							style={{ width: '45%' }}
+							className='input'
+							onChange={e => setTime(e.target.value)}
+						/>
+					</label>
+					<label className='temp-label'>Temp:
+						<input
+							name="temp"
+							type="number"
+							min="90"
+							max="110"
+							placeholder='--'
+							value={temp}
+							className='input'
+							aria-label='temperature-input'
+							onChange={e => setTemp(e.target.value)} 
+							required
+						/>
+						<div className='BBT-deg'>°F</div>
+					</label>
+					<label>Symptoms:
+						<MultiSelect
+							options={symptoms}
+							value={selected}
+							onChange={setSelected}
+							labelledBy={"Select"}
+							className='multi-select'
+						/>
+					</label>
+					<button
+						className='submit'
+						type='button'
+						onClick={handleSubmit}
+					>
+						SUBMIT
+					</button>
+				</form>
+			}
 		</main>
   )
 }

--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -1,16 +1,32 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Days } from '../App/App';
+import moment from 'moment';
 
-const Home = () => {
+export interface HomeProps {
+	days: Days[];
+}
+
+const Home: React.FC<HomeProps> = ({ days }) => {
+	const today = moment(new Date()).format("MM/DD/YYYY")
+	//TODO: make today's msg dynamic
+
 	return (
 		<main className='Main-User-View'>
 			<section className='home-container1'>
 				<img src={require('../assets/papaya.png')} alt="Papaya" title="Papaya" className='home-img' />
 			</section>
 			<section className='home-container2'>
-				<p className='welcome-msg'>
-					{`Today is a LOW-RISK day`}
-				</p>
+				{days.find(x => x.date === today) &&
+					<p className='welcome-msg'>
+						{`Today is a LOW-RISK day`}
+					</p>
+				}
+				{!days.find(x => x.date === today) &&
+					<section className='welcome-msg'>
+						Don't forget to <Link to='/new-entry' style={{textDecoration: 'none', color: '#FBCE90', fontWeight: 'bolder'}}>log</Link> your basal body temp today!
+					</section>
+				}
 			</section>
 		</main>
 	)

--- a/src/Info/Info.tsx
+++ b/src/Info/Info.tsx
@@ -4,7 +4,9 @@ const Info = () => {
 	return (
 		<main className='Main-User-View' style={{ justifyContent: 'flex-start' }}>
 			<p className='info-paragraph'>
-				Lono makes use of the Fertility Awareness Methods also called Natural Birth Control. By tracking your basal body temperature each morning, high risk and low risk fertility days can be calculated with a 99.6% effectiveness rate.
+				For best results, take your temperature at the same time first thing every morning. After 3 cycles, enough data is collected for reliable predictions.
+
+				<p>Lono makes use of the Fertility Awareness Methods also called Natural Birth Control. By tracking your basal body temperature each morning, high risk and low risk fertility days can be calculated with a 99.6% effectiveness rate.</p>
 				
 				<p>Lono is not liable if one does fall pregnant. Please consult your personal doctor for ultimate assurance.</p>
 			</p>

--- a/src/Profile/Profile.tsx
+++ b/src/Profile/Profile.tsx
@@ -7,17 +7,18 @@ import { userDetails } from '../App/App';
 export interface ProfileProps {
   logoutUser: Function;
   postUserData: Function;
-  userData: userDetails[];
+	userData: userDetails[];
+	username: string;
   error: string;
 }
 
-const Profile: React.SFC<ProfileProps> = ({logoutUser, postUserData, userData, error}) => {
+const Profile: React.SFC<ProfileProps> = ({logoutUser, postUserData, userData, username, error}) => {
   return (
     <main className='profile'>
       <h1 className='headings'>Profile</h1>
       <section className='profile-container'>
         {error && <p className='error-msg'>Oh no! Something went wrong. Please try again.</p>}
-        {!error && userData.length > 0 &&  (
+        {!error && userData.find(x => x.name === username) &&  (
           <>
             <p>
             <span>Last Ovulation: </span> <br/>{userData[userData.length-1].start_date}
@@ -30,7 +31,7 @@ const Profile: React.SFC<ProfileProps> = ({logoutUser, postUserData, userData, e
             </p>
           </>)
         }
-        {!error && !userData.length && <ProfileForm postUserData={postUserData}/>}
+        {!error && !userData.find(x => x.name === username) && <ProfileForm postUserData={postUserData}/>}
       </section>
       <Link to='/'>
         <button className='logout-button' type='button' onClick={(event) => logoutUser(event)}>

--- a/src/Profile/Profile.tsx
+++ b/src/Profile/Profile.tsx
@@ -31,7 +31,7 @@ const Profile: React.SFC<ProfileProps> = ({logoutUser, postUserData, userData, u
             </p>
           </>)
         }
-        {!error && !userData.find(x => x.name === username) && <ProfileForm postUserData={postUserData}/>}
+        {!error && !userData.find(x => x.name === username) && <ProfileForm postUserData={postUserData} username={username} />}
       </section>
       <Link to='/'>
         <button className='logout-button' type='button' onClick={(event) => logoutUser(event)}>

--- a/src/ProfileForm/ProfileForm.tsx
+++ b/src/ProfileForm/ProfileForm.tsx
@@ -2,17 +2,18 @@ import React, { useState } from 'react';
 import './ProfileForm.scss';
 
 export interface ProfileFormProps {
-  postUserData: Function;
+	postUserData: Function;
+	username: string
 }
 
-const ProfileForm: React.SFC<ProfileFormProps> = ({ postUserData }) => {
+const ProfileForm: React.SFC<ProfileFormProps> = ({ postUserData, username }) => {
 	const [ lastOvulation, setLastOvulation ] = useState('');
   const [ avgCycleLength, setAvgCycleLength ] = useState('');
 	const [ avgPeriodLength, setAvgPeriodLength ] = useState('');
 
 	const handleSubmit = async (event: any) => {
     event.preventDefault();
-    postUserData(lastOvulation, avgCycleLength, avgPeriodLength)
+    postUserData(lastOvulation, avgCycleLength, avgPeriodLength, username)
 	}
 
   return (

--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -12,6 +12,7 @@ export const submitDay = async (temp: string, date: string) => {
 
 	if (response.ok) {
 		const data = await response.json();
+		console.log(data);
 		return data;
 	} else {
 		throw new Error(response.statusText);

--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -42,7 +42,7 @@ export const getUserData = async () => {
 	}
 }
 
-export const submitUserData = async (startDate: string, avgLength: number, avgCycle: number) => {
+export const submitUserData = async (startDate: string, avgLength: number, avgCycle: number, username: string) => {
 	const response = await fetch(`${rootUrl}/user_data`, {
 		method: 'POST',
 		headers: { "Content-Type": "application/json" },
@@ -50,6 +50,7 @@ export const submitUserData = async (startDate: string, avgLength: number, avgCy
 			"start_date": startDate,
 			"avg_length": avgLength,
 			"avg_cycle": avgCycle,
+			"name": username
 		})
 	});
 

--- a/src/index.css
+++ b/src/index.css
@@ -90,3 +90,17 @@ nav {
 	text-align: left;
 	line-height: 1.6;
 }
+
+.welcome-msg {
+	color: #FFF6E9;
+	font-family: 'Capriola', sans-serif;
+	font-size: 2.8vh;
+	background-color: #172A35;
+	border-radius: 10px;
+	width: 80vw;
+	height: 15vh;
+	margin-left: 5%;
+	padding-top: 10%;
+	padding-left: 5%;
+	padding-right: 5%;
+}


### PR DESCRIPTION
**Type of change made**:
- [ ] Configuration / setup
- [ ] Bugfix
- [x] New feature
- [x] Styling
- [ ] Testing

**Detailed Description**:
- Profile form conditionally renders form or info based on the name property of user data
- When user finishes day form, receipt is shown (soon the form should disable right away -- when our posts are linked to the gets on days_data)
- Home page will either prompt user to fill out today's entry (log is a link), or show what today's risk is if the form is already filled out
- Form is disabled if today has already been logged (with mocked data you can check)
- As soon as user fills out profile form, the profile page reloads to show their submitted data
- Mocked data traded out for API calls for data population

**Screenshots (if applicable)**:
![Screen Shot 2020-09-14 at 5 40 03 PM](https://user-images.githubusercontent.com/59381432/93149443-98b81080-f6b3-11ea-9a22-129dbd6bb035.png)
![Screen Shot 2020-09-14 at 5 40 51 PM](https://user-images.githubusercontent.com/59381432/93149444-9a81d400-f6b3-11ea-803b-8cdf8ea6d5c8.png)
![Screen Shot 2020-09-14 at 5 51 40 PM](https://user-images.githubusercontent.com/59381432/93149447-9b1a6a80-f6b3-11ea-8eed-2029307faf77.png)
![Screen Shot 2020-09-14 at 5 51 59 PM](https://user-images.githubusercontent.com/59381432/93149448-9bb30100-f6b3-11ea-9fe1-b6113a33b3e8.png)

**Questions leftover**:
It'd be cool if the user could edit their personal data. But I'm not sure if our BE is setup for that. So it'd be a hacky, new user_data POST that just replaces the current one.